### PR TITLE
fix: add blacklist words fn to filter sensitive info on status page

### DIFF
--- a/fastlane/api/status.py
+++ b/fastlane/api/status.py
@@ -71,7 +71,10 @@ def status():
     }
 
     for job in scheduled_jobs:
-        j = job.to_dict(include_executions=False)
+        j = job.to_dict(
+            include_executions=False,
+            blacklist_fn=current_app.blacklist_words_fn,
+        )
 
         itr = croniter.croniter(job.metadata["cron"], datetime.utcnow())
         j["nextScheduledAt"] = itr.get_next(datetime).isoformat()


### PR DESCRIPTION
Status page is displaying sensitive info without filter.