### PR TITLE
Add a check-sec function to Makefile and to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ jobs:
         - docker-compose --project-name fastlane-tests -f ./docker-compose-func-ci.yml up -d
       script: make func
 script:
-  - make deps unit
+  - make check-sec deps unit

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,14 @@ setup-ci:
 	@pip install poetry
 	@poetry develop
 
+check-sec:
+ifdef COMPOSE
+	@echo "Installing Bandit..."
+	@pip install bandit
+	@echo "Running Bandit..."
+	@bandit -r .
+endif
+
 deps:
 ifdef COMPOSE
 	@echo "Starting dependencies..."

--- a/fastlane/cli/core.py
+++ b/fastlane/cli/core.py
@@ -29,7 +29,7 @@ def version():
 
 
 @click.command()
-@click.option("-b", "--host", default="0.0.0.0")
+@click.option("-b", "--host", default="0.0.0.0") # nosec
 @click.option("-p", "--port", default=10000)
 @click.option("-v", "--verbose", default=0, count=True)
 @click.option(


### PR DESCRIPTION
This PR will add [Bandit](https://github.com/PyCQA/bandit) as a new check of the project's CI and also add a `# nosec` tag into a line of code that can be considered as a false positive.

From now on, every diff in the code will be scanned for vulnerabilities and, if any is found, tests will fail. 🙃 When [huskyCI](https://github.com/globocom/huskyCI) provides us with a public platform to be used for Open Source projects, we could eventually use it! 🐼